### PR TITLE
fix contract generation

### DIFF
--- a/src/main/java/one/harmony/codegen/SolidityFunctionWrapper.java
+++ b/src/main/java/one/harmony/codegen/SolidityFunctionWrapper.java
@@ -556,7 +556,10 @@ public class SolidityFunctionWrapper extends Generator {
 		String inputParams = addParameters(methodBuilder, functionDefinition.getInputs());
 
 		List<TypeName> outputParameterTypes = buildTypeNames(functionDefinition.getOutputs());
-		if (functionDefinition.isConstant()) {
+		String stateMutability = functionDefinition.getStateMutability();
+        	boolean pureOrView = "pure".equals(stateMutability) || "view".equals(stateMutability);
+        	boolean isFunctionDefinitionConstant = functionDefinition.isConstant() || pureOrView;
+		if (isFunctionDefinitionConstant) {
 			buildConstantFunction(functionDefinition, methodBuilder, outputParameterTypes, inputParams);
 		} else {
 			buildTransactionFunction(functionDefinition, methodBuilder, inputParams);


### PR DESCRIPTION
with the version 1.0.23 a bug has been introduced: the functions with states pure and view are not recognized as such, therefore the send() methods doesn't return a decoded result but only the transaction receipt