### PR TITLE
fix signature bug when r or s lead with 0x00 the cannot pass Identify

### DIFF
--- a/src/main/java/one/harmony/transaction/Transaction.java
+++ b/src/main/java/one/harmony/transaction/Transaction.java
@@ -256,10 +256,24 @@ public class Transaction {
 			headerByte += recId;
 		}
 
-		// 1 header + 32 bytes for R + 32 bytes for S
+
+
+		
+		int rLen = 32;
+		int sLen = 32;
+		BigInteger base = new BigInteger("256");
+		for(int bytes=31;bytes>0;bytes--) {
+			if(sig.r.divide(base.pow(bytes)).compareTo(BigInteger.ONE)<0){
+				rLen =bytes;
+			}
+			if(sig.s.divide(base.pow(bytes)).compareTo(BigInteger.ONE)<0){
+				sLen = bytes;
+			}
+		}
+
 		byte v = (byte) headerByte;
-		byte[] r = Numeric.toBytesPadded(sig.r, 32);
-		byte[] s = Numeric.toBytesPadded(sig.s, 32);
+		byte[] r = Numeric.toBytesPadded(sig.r, rLen);
+		byte[] s = Numeric.toBytesPadded(sig.s, sLen);
 
 		return new SignatureData(v, r, s);
 	}


### PR DESCRIPTION
Recently , we got a failed tx returned by harmony Node 

> rlp: non-canonical integer (leading zero bytes) for *[big.Int](http://big.int/), decoding into (types.StakingTransaction)(types.txdata).S

By getting the failed tx data,we found that the signature is divided into 3 parts(v,r,s),and the s is lead with 0x00
<img width="968" alt="image" src="https://user-images.githubusercontent.com/24826935/160114291-6d2bd68e-84a6-4dfb-a2c9-d0c12db87a34.png">


And I refered to this link [https://github.com/MOACChain/moac-core/issues/24](url) to fix this bug,and now we have tested it and it can send transactions normally